### PR TITLE
Move ttyhascolor to after process.jl, fix fake_repl

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -241,6 +241,7 @@ include("filesystem.jl")
 using .Filesystem
 include("cmd.jl")
 include("process.jl")
+include("ttyhascolor.jl")
 include("grisu/grisu.jl")
 include("secretbuffer.jl")
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -112,7 +112,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
     have_color = get(stdout, :color, false)
     while true
         try
-            if have_color === true
+            if have_color
                 print(color_normal)
             end
             if lasterr !== nothing
@@ -124,7 +124,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
                 value = Core.eval(Main, ast)
                 ccall(:jl_set_global, Cvoid, (Any, Any, Any), Main, :ans, value)
                 if !(value === nothing) && show_value
-                    if have_color === true
+                    if have_color
                         print(answer_color())
                     end
                     try

--- a/base/client.jl
+++ b/base/client.jl
@@ -112,7 +112,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
     have_color = get(stdout, :color, false)
     while true
         try
-            if have_color
+            if have_color === true
                 print(color_normal)
             end
             if lasterr !== nothing
@@ -124,7 +124,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
                 value = Core.eval(Main, ast)
                 ccall(:jl_set_global, Cvoid, (Any, Any, Any), Main, :ans, value)
                 if !(value === nothing) && show_value
-                    if have_color
+                    if have_color === true
                         print(answer_color())
                     end
                     try
@@ -493,7 +493,7 @@ function _start()
         invokelatest(display_error, catch_stack())
         exit(1)
     end
-    if is_interactive && have_color
+    if is_interactive && have_color === true
         print(color_normal)
     end
 end

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -485,29 +485,6 @@ function displaysize(io::TTY)
     return h, w
 end
 
-function ttyhascolor()
-    term_type = get(ENV, "TERM","")
-    startswith(term_type, "xterm") && return true
-    try
-        @static if Sys.KERNEL === :FreeBSD
-            return success("tput AF 0")
-        else
-            return success("tput setaf 0")
-        end
-    catch
-        return false
-    end
-end
-function get_have_color()
-    global have_color
-    have_color === nothing && (have_color = ttyhascolor())
-    return have_color::Bool
-end
-in(key_value::Pair{Symbol,Bool}, ::TTY) = key_value.first === :color && key_value.second === get_have_color()
-haskey(::TTY, key::Symbol) = key === :color
-getindex(::TTY, key::Symbol) = key === :color ? get_have_color() : throw(KeyError(key))
-get(::TTY, key::Symbol, default) = key === :color ? get_have_color() : default
-
 ### Libuv callbacks ###
 
 ## BUFFER ##

--- a/base/ttyhascolor.jl
+++ b/base/ttyhascolor.jl
@@ -1,0 +1,24 @@
+function ttyhascolor()
+    term_type = get(ENV, "TERM","")
+    startswith(term_type, "xterm") && return true
+    try
+        @static if Sys.KERNEL === :FreeBSD
+            return success(`tput AF 0`)
+        else
+            return success(`tput setaf 0`)
+        end
+    catch e
+        return false
+    end
+end
+function get_have_color()
+    global have_color
+    have_color === nothing && (have_color = ttyhascolor())
+    return have_color
+end
+in(key_value::Pair{Symbol,Bool}, ::TTY) = key_value.first === :color && key_value.second === get_have_color()
+haskey(::TTY, key::Symbol) = key === :color
+getindex(::TTY, key::Symbol) = key === :color ? get_have_color() : throw(KeyError(key))
+get(::TTY, key::Symbol, default) = key === :color ? get_have_color() : default
+
+

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1168,17 +1168,17 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     dopushdisplay = !in(d,Base.Multimedia.displays)
     dopushdisplay && pushdisplay(d)
     while !eof(repl.stream)
-        if have_color
+        if have_color === true
             print(repl.stream,repl.prompt_color)
         end
         print(repl.stream, "julia> ")
-        if have_color
+        if have_color === true
             print(repl.stream, input_color(repl))
         end
         line = readline(repl.stream, keep=true)
         if !isempty(line)
             ast = Base.parse_input_line(line)
-            if have_color
+            if have_color === true
                 print(repl.stream, Base.color_normal)
             end
             response = eval_with_backend(ast, backend)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1168,17 +1168,17 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     dopushdisplay = !in(d,Base.Multimedia.displays)
     dopushdisplay && pushdisplay(d)
     while !eof(repl.stream)
-        if have_color === true
+        if have_color
             print(repl.stream,repl.prompt_color)
         end
         print(repl.stream, "julia> ")
-        if have_color === true
+        if have_color
             print(repl.stream, input_color(repl))
         end
         line = readline(repl.stream, keep=true)
         if !isempty(line)
             ast = Base.parse_input_line(line)
-            if have_color === true
+            if have_color
                 print(repl.stream, Base.color_normal)
             end
             response = eval_with_backend(ast, backend)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -51,7 +51,10 @@ function fake_repl(@nospecialize(f); options::REPL.Options=REPL.Options(confirm_
     repl.options = options
 
     hard_kill = kill_timer(900) # Your debugging session starts now. You have 15 minutes. Go.
+    @eval Base old_have_color = have_color
+    @eval Base have_color = false
     f(input.in, output.out, repl)
+    @eval Base have_color = old_have_color
     t = @async begin
         close(input.in)
         close(output.in)


### PR DESCRIPTION
This PR moves ttyhascolor to after process.jl so that it can compile. It also fixes `fake_repl` to deactivate colors so that the test succeeds.